### PR TITLE
Fix ImportError in Python 3.10: Update Iterable import

### DIFF
--- a/play3d/models.py
+++ b/play3d/models.py
@@ -2,7 +2,10 @@ import copy
 import math
 import numbers
 import urllib.request
-from collections import Iterable
+if sys.version_info >= (3, 10):
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 from inspect import signature
 
 import numpy


### PR DESCRIPTION
### Description
This pull request addresses an issue encountered in Python 3.10, where the direct import of Iterable from collections is no longer supported. The code has been updated to import Iterable from collections.abc when the Python version is 3.10 or newer, ensuring compatibility with the latest Python release.

### Changes Made
Updated the import statement for Iterable to resolve the ImportError in Python 3.10.

### Additional Notes
This change is backward compatible with older Python versions.
No other functionality has been affected.